### PR TITLE
Rename SpatialImage to VirtualSpatialImage class

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: spatialLIBD
 Title: spatialLIBD: an R/Bioconductor package to visualize spatially-resolved
     transcriptomics data
-Version: 1.7.12
-Date: 2022-03-01
+Version: 1.7.13
+Date: 2022-03-03
 Authors@R:
     c(
     person("Leonardo", "Collado-Torres", role = c("aut", "cre"), 

--- a/R/check_spe.R
+++ b/R/check_spe.R
@@ -42,7 +42,7 @@ check_spe <- function(spe,
     ) %in% colnames(imgData(spe))))
 
     ## Check that the images have been loaded
-    stopifnot(all(vapply(imgData(spe)$data, is, logical(1), "SpatialImage")))
+    stopifnot(all(vapply(imgData(spe)$data, is, logical(1), "VirtualSpatialImage")))
 
     ## Check gene data
     stopifnot(all(


### PR DESCRIPTION
This is to fix the current error in the `spatialLIBD` build report for version 1.7.12, which is due to the renaming of the `SpatialImage` class to `VirtualSpatialImage` in `SpatialExperiment` version 1.5.3.

`spatialLIBD::check_spe()` was using the old class name `SpatialImage` for a check, so this was returning an error in the vignette where this function is used. Renaming this to `VirtualSpatialImage` in `spatialLIBD::check_spe()` should fix it.