### PR TITLE
In gene_set_enrichment use alternative greater

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@ $run_dev.*
 ^pkgdown$
 ^codecov\.yml$
 ^\.github$
+^spatialLIBD\.Rproj$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: spatialLIBD
 Title: spatialLIBD: an R/Bioconductor package to visualize spatially-resolved
     transcriptomics data
-Version: 1.11.8
+Version: 1.11.9
 Date: 2023-02-22
 Authors@R:
     c(

--- a/R/gene_set_enrichment.R
+++ b/R/gene_set_enrichment.R
@@ -71,6 +71,16 @@ gene_set_enrichment <-
             x <- x[!is.na(x)]
             x[x %in% model_results$ensembl]
         })
+        
+        ## warn about low power for small geneLists
+        geneList_length <- sapply(geneList_present, length)
+        min_genes <- 25
+        if(any(geneList_length < min_genes)){
+          warning(
+            "Gene list with n < ",min_genes," may have insufficent power for enrichment analysis: ", 
+               paste(names(geneList_length)[geneList_length < 200], collapse = " ,")
+          )
+        } 
 
         tstats <-
             model_results[, grep("[f|t]_stat_", colnames(model_results))]

--- a/R/gene_set_enrichment.R
+++ b/R/gene_set_enrichment.R
@@ -2,8 +2,10 @@
 #'
 #' Using the layer-level (group-level) data, this function evaluates whether
 #' list of gene sets (Ensembl gene IDs) are enriched among the significant
-#' genes (FDR < 0.1 by default) genes for a given model type result. If you want
-#' to check depleted genes, change `reverse` to `TRUE`.
+#' genes (FDR < 0.1 by default) genes for a given model type result. Test the
+#' alternative hypothesis that OR > 1, i.e. that gene set is over-represented in the 
+#' set of enriched genes. If you want to check depleted genes, change `reverse`
+#' to `TRUE`.
 #'
 #' @param gene_list A named `list` object (could be a `data.frame`) where each
 #' element of the list is a character vector of Ensembl gene IDs.

--- a/R/gene_set_enrichment.R
+++ b/R/gene_set_enrichment.R
@@ -100,7 +100,8 @@ gene_set_enrichment <-
                         Layer = factor(layer, c(FALSE, TRUE))
                     )
                 })
-                enrichList <- lapply(tabList, fisher.test)
+                
+                enrichList <- lapply(tabList, fisher.test, alternative = "greater")
                 o <- data.frame(
                     OR = vapply(enrichList, "[[", numeric(1), "estimate"),
                     Pval = vapply(enrichList, "[[", numeric(1), "p.value"),

--- a/man/gene_set_enrichment.Rd
+++ b/man/gene_set_enrichment.Rd
@@ -46,8 +46,10 @@ A table in long format with the enrichment results using
 \description{
 Using the layer-level (group-level) data, this function evaluates whether
 list of gene sets (Ensembl gene IDs) are enriched among the significant
-genes (FDR < 0.1 by default) genes for a given model type result. If you want
-to check depleted genes, change \code{reverse} to \code{TRUE}.
+genes (FDR < 0.1 by default) genes for a given model type result. Test the
+alternative hypothesis that OR > 1, i.e. that gene set is over-represented in the
+set of enriched genes. If you want to check depleted genes, change \code{reverse}
+to \code{TRUE}.
 }
 \details{
 Check

--- a/tests/testthat/test-gene_set_enrichment.R
+++ b/tests/testthat/test-gene_set_enrichment.R
@@ -49,7 +49,7 @@ edge_safari_enrichment <- gene_set_enrichment(
   model_type = "enrichment"
 )
 
-## with Ha 
+## with alternative = "two.sided"
 # OR         Pval   test NumSig SetSize           ID model_type fdr_cut
 # 1 0.0000000 5.752600e-72     WM      0     638 no_WM_enrich enrichment     0.1
 
@@ -61,8 +61,8 @@ test_that("warn for small gene list", {
   )
 })
 
-test_that("Not signficant for OR",{
-  
+test_that("Not signficant for OR==0",{
+  expect_true(all(edge_safari_enrichment$Pval[edge_safari_enrichment$OR == 0] > 0.05))
 })
 
 

--- a/tests/testthat/test-gene_set_enrichment.R
+++ b/tests/testthat/test-gene_set_enrichment.R
@@ -1,0 +1,68 @@
+
+asd_sfari <- utils::read.csv(
+      system.file(
+          "extdata",
+          "SFARI-Gene_genes_01-03-2020release_02-04-2020export.csv",
+          package = "spatialLIBD"
+      ),
+      as.is = TRUE
+  )
+
+  ## Format them appropriately
+  asd_sfari_geneList <- list(
+      Gene_SFARI_all = asd_sfari$ensembl.id,
+      Gene_SFARI_high = asd_sfari$ensembl.id[asd_sfari$gene.score < 3],
+      Gene_SFARI_syndromic = asd_sfari$ensembl.id[asd_sfari$syndromic == 1]
+  )
+
+  ## Obtain the necessary data
+  if (!exists("modeling_results")) {
+      modeling_results <- fetch_data(type = "modeling_results")
+  }
+
+  
+  ## Compute the gene set enrichment results
+  asd_sfari_enrichment <- gene_set_enrichment(
+      gene_list = asd_sfari_geneList,
+      modeling_results = modeling_results,
+      model_type = "enrichment"
+  )
+  
+
+test_that("result for each gene list & model test", {
+  expect_equal(nrow(asd_sfari_enrichment), 
+               length(asd_sfari_geneList)*length(grep("fdr",colnames(modeling_results$enrichment))))
+})
+
+## check behavior for  OR < 1 results
+WM_enriched <- modeling_results$enrichment$fdr_WM < 0.1 & modeling_results$enrichment$t_stat_WM > 0
+gene_in_set <- experiment_genes %in% asd_sfari_geneList$Gene_SFARI_all
+
+safari_no_wm_enrich <- asd_sfari_geneList$Gene_SFARI_all[asd_sfari_geneList$Gene_SFARI_all %in% modeling_results$enrichment$ensembl[!WM_enriched]]
+
+safari_edge_cases <- list(no_WM_enrich = safari_no_wm_enrich,
+                          short = asd_sfari_geneList$Gene_SFARI_all[1:20])
+
+edge_safari_enrichment <- gene_set_enrichment(
+  gene_list = safari_edge_cases["no_WM_enrich"],
+  modeling_results = modeling_results,
+  model_type = "enrichment"
+)
+
+## with Ha 
+# OR         Pval   test NumSig SetSize           ID model_type fdr_cut
+# 1 0.0000000 5.752600e-72     WM      0     638 no_WM_enrich enrichment     0.1
+
+test_that("warn for small gene list", {
+  expect_warning(gene_set_enrichment(
+    gene_list = safari_edge_cases["short"],
+    modeling_results = modeling_results,
+    model_type = "enrichment")
+  )
+})
+
+test_that("Not signficant for OR",{
+  
+})
+
+

--- a/tests/testthat/test-gene_set_enrichment.R
+++ b/tests/testthat/test-gene_set_enrichment.R
@@ -20,23 +20,22 @@ asd_sfari <- utils::read.csv(
       modeling_results <- fetch_data(type = "modeling_results")
   }
 
-  
+
   ## Compute the gene set enrichment results
   asd_sfari_enrichment <- gene_set_enrichment(
       gene_list = asd_sfari_geneList,
       modeling_results = modeling_results,
       model_type = "enrichment"
   )
-  
+
 
 test_that("result for each gene list & model test", {
-  expect_equal(nrow(asd_sfari_enrichment), 
+  expect_equal(nrow(asd_sfari_enrichment),
                length(asd_sfari_geneList)*length(grep("fdr",colnames(modeling_results$enrichment))))
 })
 
 ## check behavior for  OR < 1 results
 WM_enriched <- modeling_results$enrichment$fdr_WM < 0.1 & modeling_results$enrichment$t_stat_WM > 0
-gene_in_set <- experiment_genes %in% asd_sfari_geneList$Gene_SFARI_all
 
 safari_no_wm_enrich <- asd_sfari_geneList$Gene_SFARI_all[asd_sfari_geneList$Gene_SFARI_all %in% modeling_results$enrichment$ensembl[!WM_enriched]]
 


### PR DESCRIPTION
While using `gene_set_enrichment` @sparthib noticed she had a significant result for a layer enrichment/gene-set pair with an OR = 0.  The gene list she was using had no overlapping genes with genes enriched for in WM, so the OR=0, but the pval < 0.05. Currently the `fisher.test` is using the default `alternative = "two.sided"` so any OR != 1 can be significant so this result is technically correct but I think deviates from described use of this function, where we are looking for where gene sets are enriched or over represented in the models significant genes, where the OR > 1. I propose we change to using `fisher.test(alternative = "greater")` to avoid detecting OR < 1. 

I also included a warning message for genes sets with n < 25 as in practice we thought they had too little power for good results.  