### PR TITLE
Read10x updates

### DIFF
--- a/R/read10xVisiumWrapper.R
+++ b/R/read10xVisiumWrapper.R
@@ -60,7 +60,18 @@ read10xVisiumWrapper <- function(
     if (missing(reference_gtf)) {
         summary_file <- file.path(samples[1], "web_summary.html")
         web <- readLines(summary_file)
+
+        #   For spaceranger versions before 3.0
         reference_path <- gsub('.*"', "", regmatches(web, regexpr('\\["Reference Path", *"[/|A-z|0-9|-]+', web)))
+
+        #   For recent spaceranger versions (3.0.0+?)
+        if (length(reference_path) == 0) {
+            reference_path = sub(
+                '.*--transcriptome=(\\S*).*',
+                '\\1', 
+                web[grep('--transcriptome=', web)]
+            )
+        }
         reference_gtf <- file.path(reference_path, "genes", "genes.gtf")
     }
     reference_gtf <- reference_gtf[file.exists(reference_gtf)]

--- a/R/read10xVisiumWrapper.R
+++ b/R/read10xVisiumWrapper.R
@@ -72,7 +72,10 @@ read10xVisiumWrapper <- function(
                 web[grep('--transcriptome=', web)]
             )
         }
-        reference_gtf <- file.path(reference_path, "genes", "genes.gtf")
+        reference_gtf <- list.files(
+            file.path(reference_path, "genes"), "^genes\\.gtf(\\.gz)?$",
+            full.names = TRUE
+        )
     }
     reference_gtf <- reference_gtf[file.exists(reference_gtf)]
     if (length(reference_gtf) > 1) {


### PR DESCRIPTION
All changes modify `read10xVisiumWrapper()` to allow finding and importing the reference GTF properly, namely when `reference_gtf` is not specified. In particular:
- Correctly find the reference GTF for recent versions of spaceranger, which have a differently organized `web_summary.html` file
- Support importing GTF files that are gzipped, which occurs for recent reference genomes (such as those from 2024)