### PR TITLE
Check var_registration is syntactically valid  in spatial registration functions

### DIFF
--- a/R/registration_pseudobulk.R
+++ b/R/registration_pseudobulk.R
@@ -8,7 +8,9 @@
 #' object or one that inherits its properties.
 #' @param var_registration A `character(1)` specifying the `colData(sce)`
 #' variable of interest against which will be used for computing the relevant
-#' statistics.
+#' statistics. This should be a categorical variable, with all categories 
+#' syntaticly valid (could be used as an R variable, no special characters or 
+#' leading numbers), ex. 'L1.2', 'celltype2' not 'L1/2' or '2'.
 #' @param var_sample_id A `character(1)` specifying the `colData(sce)` variable
 #' with the sample ID.
 #' @param covars A `character()` with names of sample-level covariates.

--- a/R/registration_pseudobulk.R
+++ b/R/registration_pseudobulk.R
@@ -70,15 +70,22 @@ registration_pseudobulk <-
         stopifnot(!var_sample_id %in% covars)
         stopifnot(var_registration != var_sample_id)
 
-        ## Check that the values in the registration variable are ok
+        ## Check that the values in the registration variable are numeric
+        if(is.numeric(sce[[var_registration]])){
+          warning(sprintf("var_registration \"%s\" is numeric, convering to catagorial vector...", 
+                       var_registration))
+        }
+        
+        ## check for Non-Syntactic variables - convert with make.names & warn
         uniq_var_regis <- unique(sce[[var_registration]])
-        if (any(grepl("\\+|\\-", uniq_var_regis))) {
-            stop(
-                "Remove the + and - signs in colData(sce)[, '",
-                var_registration,
-                "'] to avoid downstream issues.",
-                call. = FALSE
+        syntatic <- grepl("^((([[:alpha:]]|[.][._[:alpha:]])[._[:alnum:]]*)|[.])$", uniq_var_regis)
+        if (!all(syntatic)) {
+            warning(sprintf("var_registration \"%s\" contains non-syntatic variables: %s\nconverting to %s",
+                         var_registration,
+                         paste(uniq_var_regis[!syntatic], collapse = ", "),
+                         paste(make.names(uniq_var_regis[!syntatic]), collapse = ", "))
             )
+                    sce[[var_registration]] <- make.names(sce[[var_registration]])
         }
 
         ## Pseudo-bulk for our current BayesSpace cluster results

--- a/man/registration_pseudobulk.Rd
+++ b/man/registration_pseudobulk.Rd
@@ -20,7 +20,9 @@ object or one that inherits its properties.}
 
 \item{var_registration}{A \code{character(1)} specifying the \code{colData(sce)}
 variable of interest against which will be used for computing the relevant
-statistics.}
+statistics. This should be a categorical variable, with all categories
+syntaticly valid (could be used as an R variable, no special characters or
+leading numbers), ex. 'L1.2', 'celltype2' not 'L1/2' or '2'.}
 
 \item{var_sample_id}{A \code{character(1)} specifying the \code{colData(sce)} variable
 with the sample ID.}

--- a/man/registration_wrapper.Rd
+++ b/man/registration_wrapper.Rd
@@ -23,7 +23,9 @@ object or one that inherits its properties.}
 
 \item{var_registration}{A \code{character(1)} specifying the \code{colData(sce)}
 variable of interest against which will be used for computing the relevant
-statistics.}
+statistics. This should be a categorical variable, with all categories
+syntaticly valid (could be used as an R variable, no special characters or
+leading numbers), ex. 'L1.2', 'celltype2' not 'L1/2' or '2'.}
 
 \item{var_sample_id}{A \code{character(1)} specifying the \code{colData(sce)} variable
 with the sample ID.}

--- a/tests/testthat/test-registration_pseudobulk.R
+++ b/tests/testthat/test-registration_pseudobulk.R
@@ -29,7 +29,7 @@ sce$batch <- "batch1"
 
 ## non-syntactic inputs
 sce$cluster_int <- sample(1:4, ncol(sce), replace = TRUE)
-sce$cluster_k <- paste0("k", sce$cluster_int)
+# sce$cluster_k <- paste0("k", sce$cluster_int)
 sce$cluster_j <- paste0(sce$cluster_int,"j")
 sce$cluster_l <- sample(c("L-1", "L2/3", "4L", "L5"), ncol(sce), replace = TRUE)
 

--- a/tests/testthat/test-registration_pseudobulk.R
+++ b/tests/testthat/test-registration_pseudobulk.R
@@ -11,3 +11,42 @@ test_that("NA check works", {
         "var_registration"
     )
 })
+
+
+#### Syntactic Variable Test ####
+set.seed(20220907) ## Ensure reproducibility of example data
+sce <- scuttle::mockSCE()
+## Add some sample IDs
+sce$sample_id <- sample(LETTERS[1:5], ncol(sce), replace = TRUE)
+
+## Add a sample-level covariate: age
+ages <- rnorm(5, mean = 20, sd = 4)
+names(ages) <- LETTERS[1:5]
+sce$age <- ages[sce$sample_id]
+
+## add variable with one group
+sce$batch <- "batch1"
+
+## non-syntactic inputs
+sce$cluster_int <- sample(1:4, ncol(sce), replace = TRUE)
+sce$cluster_k <- paste0("k", sce$cluster_int)
+sce$cluster_j <- paste0(sce$cluster_int,"j")
+sce$cluster_l <- sample(c("L-1", "L2/3", "4L", "L5"), ncol(sce), replace = TRUE)
+
+test_that("warn for numeric var_registration",
+          expect_warning(registration_pseudobulk(sce,
+                                  var_registration = "cluster_int",
+                                  var_sample_id = "sample_id", 
+                                  covars = c("age"), 
+                                  min_ncells = NULL))
+)
+
+
+test_that("warn for non-syntactic var_registration",
+          expect_warning(registration_pseudobulk(sce,
+                                                 var_registration = "cluster_l",
+                                                 var_sample_id = "sample_id", 
+                                                 covars = c("age"), 
+                                                 min_ncells = NULL))
+)
+

--- a/tests/testthat/test-registration_wrapper.R
+++ b/tests/testthat/test-registration_wrapper.R
@@ -34,3 +34,43 @@ test_that(
         )
     )
 )
+
+#### Syntactic Variable Test ####
+
+## catagorical var as int
+sce$cluster_int <- sample(1:4, ncol(sce), replace = TRUE)
+# sce$cluster_k <- paste0("k", sce$cluster_int)
+sce$cluster_j <- paste0(sce$cluster_int,"j")
+sce$cluster_l <- sample(c("L-1", "L2/3", "4L", "L5"), ncol(sce), replace = TRUE)
+
+table(sce$cluster_j)
+
+test_that("Numeric var_regisration throws warning",
+          expect_warning(registration_wrapper(
+            sce,
+            var_registration = "cluster_int",
+            var_sample_id = "sample_id",
+            covars = c("age"),
+            gene_ensembl = "ensembl",
+            gene_name = "gene_name",
+            suffix = "wrapper"
+          )))
+
+test_that("Non-Syntactic thows warning",
+          expect_warning(registration_wrapper(
+            sce,
+            var_registration = "cluster_l",
+            var_sample_id = "sample_id",
+            covars = c("age"),
+            gene_ensembl = "ensembl",
+            gene_name = "gene_name",
+            suffix = "wrapper"
+          )))
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Add grepl test ([regex source](https://stackoverflow.com/questions/8396577/check-if-character-value-is-a-valid-r-object-name)) for `var_registration` to be syntactically valid. If not, use `makes.names()` to correct to syntactically valid names instead and warn user of the change. Also warn if variable is numeric, and convert to syntactically valid names w/ `make.names()` . 
 
Addresses issues #72 and #48.
