### PR TITLE
Fix handling of NAs in `get_colors()`

### DIFF
--- a/R/get_colors.R
+++ b/R/get_colors.R
@@ -40,11 +40,9 @@
 #'     prob = c(0.3, 0.15, 0.55)
 #' )
 #' log_var_sorted <- sort_clusters(log_var)
-#' ## A color does get assigned to 'NA', but will be overwritten by
-#' ## 'na_color' passed to `vis_clus_p()` and related functions.
 #' get_colors(colors = NULL, clusters = log_var_sorted)
 get_colors <- function(colors = NULL, clusters) {
-    n_clus <- length(unique(clusters))
+    n_clus <- length(unique(clusters[!is.na(clusters)]))
 
     if (is.null(colors) | n_clus > length(colors)) {
         ## Original ones

--- a/man/get_colors.Rd
+++ b/man/get_colors.Rd
@@ -48,7 +48,5 @@ log_var <- sample(c(TRUE, FALSE, NA),
     prob = c(0.3, 0.15, 0.55)
 )
 log_var_sorted <- sort_clusters(log_var)
-## A color does get assigned to 'NA', but will be overwritten by
-## 'na_color' passed to `vis_clus_p()` and related functions.
 get_colors(colors = NULL, clusters = log_var_sorted)
 }


### PR DESCRIPTION
## Background

Currently, NAs in categorical variables [are given their own color](https://github.com/LieberInstitute/spatialLIBD/blob/1836f77a635b68b32e6fe0c7ac68ad46bb1c6929/R/get_colors.R#L47). Combined with [this line](https://github.com/LieberInstitute/spatialLIBD/blob/1836f77a635b68b32e6fe0c7ac68ad46bb1c6929/R/get_colors.R#L49), this leads to the unexpected behavior that custom colors provided to `vis_clus(colors = some_colors)` are ignored for categorical variables with NAs and 12 unique non-NA values.

## Fix

After the commit in this PR, NAs are not counted as a unique color. I've checked that colors in plots now behave as expected under 12 combinations of conditions when `colors` is supplied:

- 2 or 12 clusters, including logical variables, keeping #80 in mind
- `vis_clus()` or `vis_grid_clus()`
- Including and not including NAs