### PR TITLE
Add guide_point_size as an arg in vis_clus

### DIFF
--- a/R/vis_clus.R
+++ b/R/vis_clus.R
@@ -39,6 +39,8 @@
 #' <http://research.libd.org/visiumStitched/reference/build_spe.html>; in
 #' particular, expects a logical colData column `exclude_overlapping`
 #' specifying which spots to exclude from the plot. Sets `auto_crop = FALSE`.
+#' @param guide_point_size A `numeric(1)` specifying the size of the points in 
+#' guide. Defaults to `point_size`. Increase to improve visability. 
 #' @param ... Passed to [paste0()][base::paste] for making the title of the
 #' plot following the `sampleid`.
 #'
@@ -102,6 +104,20 @@
 #'         ... = " LIBD Layers"
 #'     )
 #'     print(p4)
+#'     
+#'     ## edit plot point size but keep guide size larger
+#'     p5 <- vis_clus(
+#'         spe = spe,
+#'         clustervar = "layer_guess_reordered",
+#'         sampleid = "151673",
+#'         colors = libd_layer_colors,
+#'         na_color = "white",
+#'         point_size = 1,
+#'         guide_point_size = 3,
+#'         ... = " LIBD Layers"
+#'     )
+#'     print(p5)
+#'          
 #' }
 vis_clus <- function(
         spe,
@@ -128,6 +144,7 @@ vis_clus <- function(
         auto_crop = TRUE,
         na_color = "#CCCCCC40",
         is_stitched = FALSE,
+        guide_point_size = point_size,
         ...) {
     #   Verify existence and legitimacy of 'sampleid'
     if (
@@ -177,5 +194,6 @@ vis_clus <- function(
         point_size = point_size,
         auto_crop = auto_crop,
         na_color = na_color
-    )
+    ) + 
+      guides(fill = guide_legend(override.aes = list(size = guide_point_size)))
 }

--- a/man/vis_clus.Rd
+++ b/man/vis_clus.Rd
@@ -17,6 +17,7 @@ vis_clus(
   auto_crop = TRUE,
   na_color = "#CCCCCC40",
   is_stitched = FALSE,
+  guide_point_size = point_size,
   ...
 )
 }
@@ -66,6 +67,9 @@ with \code{visiumStitched::build_spe()}.
 \url{http://research.libd.org/visiumStitched/reference/build_spe.html}; in
 particular, expects a logical colData column \code{exclude_overlapping}
 specifying which spots to exclude from the plot. Sets \code{auto_crop = FALSE}.}
+
+\item{guide_point_size}{A \code{numeric(1)} specifying the size of the points in
+guide. Defaults to \code{point_size}. Increase to improve visability.}
 
 \item{...}{Passed to \link[base:paste]{paste0()} for making the title of the
 plot following the \code{sampleid}.}
@@ -135,6 +139,20 @@ if (enough_ram()) {
         ... = " LIBD Layers"
     )
     print(p4)
+    
+    ## edit plot point size but keep guide size larger
+    p5 <- vis_clus(
+        spe = spe,
+        clustervar = "layer_guess_reordered",
+        sampleid = "151673",
+        colors = libd_layer_colors,
+        na_color = "white",
+        point_size = 1,
+        guide_point_size = 3,
+        ... = " LIBD Layers"
+    )
+    print(p5)
+         
 }
 }
 \seealso{


### PR DESCRIPTION
Adding `guide_point_size` allows users to easily change the size of points in the guide for `vis_clus()` plots. Typically to make the larger and more read-able, even when `point_size` gets quite small. 

Example without `guide_point_size`
![vis_clus_test_no_change](https://github.com/user-attachments/assets/3a5adaf2-6401-44f9-ab56-32583663dc4e)

Setting `guide_point_size = 5`
![vis_clus_test_guide_point_size](https://github.com/user-attachments/assets/9c8696b8-3156-4df3-9e90-ca7ce03445d6)