### PR TITLE
Fix: return results_anova to registration_wrapper()

### DIFF
--- a/R/registration_wrapper.R
+++ b/R/registration_wrapper.R
@@ -134,7 +134,7 @@ registration_wrapper <-
 
         ## Bundle results together
         modeling_results <- list(
-            "anova" = NULL,
+            "anova" = results_anova,
             "enrichment" = results_enrichment,
             "pairwise" = results_pairwise
         )


### PR DESCRIPTION
Replace NULL with results_anova
fix bug #109 